### PR TITLE
解决消息重复相应的bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,13 @@ Wechat.prototype.handler = function(req, res) {
   req.on('end', function() {
     self.toJSON(xml);
   });
+
+  /**
+   * clear all listening events to avoid repeat triggers
+   */
+  emitter.removeAllListeners('text');
+  emitter.removeAllListeners('voice');
+  emitter.removeAllListeners('event');
 }
 
 //解析器
@@ -122,55 +129,55 @@ Wechat.prototype.toJSON = function(xml) {
 
 //监听文本信息
 Wechat.prototype.text = function(callback) {
-  emitter.on("text", callback);
+  emitter.once("text", callback);
   return this;
 }
 
 //监听图片信息
 Wechat.prototype.image = function(callback) {
-  emitter.on("image", callback);
+  emitter.once("image", callback);
   return this;
 }
 
 //监听地址信息
 Wechat.prototype.location = function(callback) {
-  emitter.on("location", callback);
+  emitter.once("location", callback);
   return this;
 }
 
 //监听链接信息
 Wechat.prototype.link = function(callback) {
-  emitter.on("link", callback);
+  emitter.once("link", callback);
   return this;
 }
 
 //监听事件信息
 Wechat.prototype.event = function(callback) {
-  emitter.on("event", callback);
+  emitter.once("event", callback);
   return this;
 }
 
 //监听语音信息
 Wechat.prototype.voice = function(callback) {
-  emitter.on("voice", callback);
+  emitter.once("voice", callback);
   return this;
 }
 
 //监听视频信息
 Wechat.prototype.video = function(callback) {
-  emitter.on("video", callback);
+  emitter.once("video", callback);
   return this;
 }
 
 //监听所有信息
 Wechat.prototype.all = function(callback) {
-  emitter.on("text", callback);
-  emitter.on("image", callback);
-  emitter.on("location", callback);
-  emitter.on("link", callback);
-  emitter.on("event", callback);
-  emitter.on("voice", callback);
-  emitter.on("video", callback);
+  emitter.once("text", callback);
+  emitter.once("image", callback);
+  emitter.once("location", callback);
+  emitter.once("link", callback);
+  emitter.once("event", callback);
+  emitter.once("voice", callback);
+  emitter.once("video", callback);
 
   return this;
 }


### PR DESCRIPTION
1、在预处理的时候，清理掉所有的事件监听，因为在模板消息这种发送成功后，微信服务器会发送到业务服务器一个回包，这会导致下次用户与微信交互会新建一
个事件监听，再加上上一次回包的创建，就会出现两次调用，以此类推，叠加，知道超出默认11个eventlisteners的限制。
2、事件创建避免重复，使用emitter.once替代emitter.on